### PR TITLE
Add xsaccess content type used in XSK

### DIFF
--- a/ide-monaco/monaco-editor.js
+++ b/ide-monaco/monaco-editor.js
@@ -34,6 +34,7 @@ exports.getEditor = function () {
 			"application/json+view",
 			"application/json+job",
 			"application/json+xsjob",
+			"application/json+xsaccess",
 			"application/json+listener",
 			"application/json+websocket",
 			"application/json+access",


### PR DESCRIPTION
Content type definition is needed to provide Open with... functionality for .xsaccess files used in XSK. 